### PR TITLE
feat: add reinstall script for build and testing

### DIFF
--- a/reinstall.sh
+++ b/reinstall.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -e
+
+pytest -v --tb=short
+python3 setup.py sdist bdist_wheel
+pip uninstall singlestore_pulse -y
+pip install dist/singlestore_pulse-0.1-py3-none-any.whl


### PR DESCRIPTION
Adds a reinstall script for building the sdk, running local test and installing the pulse sdk locally.
This is much needed for speeding up local testing.