### PR TITLE
Lock Python dependencies to specific versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,8 +2,8 @@ opentelemetry-api>=1.20.0
 opentelemetry-sdk>=1.20.0
 opentelemetry-exporter-otlp>=1.20.0
 opentelemetry-exporter-otlp-proto-grpc>=1.20.0
-openai
-python-dotenv
-traceloop-sdk
-fastapi
-pytest
+openai>=1.78.1
+python-dotenv>=1.1.0
+traceloop-sdk>=0.40.4
+fastapi>=0.115.12
+pytest>=8.3.5


### PR DESCRIPTION
Lock Python dependencies to specific versions in `requirements.txt`.  `traceloop-sdk` does not have `telemetry_enabled` in the older versions.  Pinning it to latest release, so the dependencies will be updated when `singlestore-pulse` is installed. Locking all the python dependencies to avoid similar issues.