### PR TITLE
Pin traceloop-sdk + OpenLLMetry instrumentors to 0.52.6

### DIFF
--- a/pulse_otel/main.py
+++ b/pulse_otel/main.py
@@ -107,7 +107,7 @@ class Pulse:
 		global _pulse_instance
 
 		if _pulse_instance is not None:
-			logger.info("Pulse instance already exists. Skipping initialization.")
+			logger.warning("Pulse already initialized; ignoring re-initialization (new configuration will not be applied).")
 			# Copy the existing instance's attributes to this instance
 			self.__dict__.update(_pulse_instance.__dict__)
 			return
@@ -258,7 +258,7 @@ class Pulse:
 			end_time = time.time()
 			logger.info(f"Pulse initialized successfully in {end_time - start_time:.2f} seconds.")
 		except Exception as e:
-			logger.error(f"Error initializing Pulse: {e}")
+			logger.error(f"Error initializing Pulse: {e}", exc_info=True)
 			
 	@staticmethod
 	def enable_content_tracing(enabled: bool = True):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,12 @@
-opentelemetry-api==1.33.1
-opentelemetry-sdk==1.33.1
-opentelemetry-exporter-otlp==1.33.1
-opentelemetry-exporter-otlp-proto-grpc==1.33.1
-traceloop-sdk==0.40.7
+opentelemetry-api==1.38.0
+opentelemetry-sdk==1.38.0
+opentelemetry-exporter-otlp==1.38.0
+opentelemetry-exporter-otlp-proto-grpc==1.38.0
+traceloop-sdk==0.52.6
+# Keep OpenLLMetry instrumentors aligned with traceloop-sdk; <0.53 preserves pre-GenAI-semconv span names (main/model/tools).
+opentelemetry-instrumentation-langchain==0.52.6
+opentelemetry-instrumentation-openai==0.52.6
+opentelemetry-instrumentation-anthropic==0.52.6
+opentelemetry-instrumentation-bedrock==0.52.6
+opentelemetry-instrumentation-ollama==0.52.6
 fastapi==0.115.12

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 with open('requirements.txt') as f:
-    requirements = f.read().splitlines()
+    requirements = [line.strip() for line in f if line.strip() and not line.startswith("#")]
 
 setup(
     name='singlestore_pulse',

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 with open('requirements.txt') as f:
-    requirements = [line.strip() for line in f if line.strip() and not line.startswith("#")]
+    requirements = [s for line in f if (s := line.strip()) and not s.startswith("#")]
 
 setup(
     name='singlestore_pulse',


### PR DESCRIPTION
## Summary

Pins the OpenLLMetry/Traceloop stack to a coherent `0.52.6` set so analyst tool spans correctly parent their downstream HTTP calls (Aura Context Service) while preserving the existing `main`/`model`/`tools` span names.

- `traceloop-sdk` `0.40.7` → `0.52.6`, otel `1.33.1` → `1.38.0`.
- Also pin the instrumentors Pulse initializes (`langchain`, `openai`, `anthropic`, `bedrock`, `ollama`) to `0.52.6`. `traceloop-sdk`'s dependency on these is loose, so without explicit pins the `langchain` instrumentor floats past `0.53.0` and switches to the new OpenTelemetry GenAI-semconv span names (`invoke_agent`/`execute_task`). `<0.53` keeps the current names.
- Surface init failures: log with `exc_info=True`, and `warning` (not `info`) when a second `Pulse()` is ignored (the singleton is reused and the new config is silently dropped).

## Test Plan

- Resolved the full set in a consumer (s2ai) against this branch: `traceloop-sdk==0.52.6`, `opentelemetry-instrumentation-langchain==0.52.6`, `opentelemetry-instrumentation-httpx==0.59b0`, `opentelemetry-sdk==1.38.0`.
- Verified in a prod analyst notebook that tool spans (`discover_relevant_table_schemas_for_user_query`) parent the Aura Context Service HTTP POST, and span names remain `main`/`model`/`tools`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Upgrades the observability stack and pins instrumentors that control span naming and trace hierarchy in production analyst flows; misalignment could break trace structure or dashboards.
> 
> **Overview**
> Aligns the **Traceloop / OpenLLMetry** dependency stack on **0.52.6** and bumps **OpenTelemetry** packages from **1.33.1** to **1.38.0**. It **explicitly pins** the LangChain, OpenAI, Anthropic, Bedrock, and Ollama instrumentors to the same version so installs do not float past **0.53** and switch to GenAI-semconv span names (`invoke_agent` / `execute_task`); the goal is stable **`main` / `model` / `tools`** naming and correct parenting of downstream HTTP spans (e.g. Aura Context Service).
> 
> **`setup.py`** now strips comments when loading **`requirements.txt`**, so inline dependency notes do not break installs.
> 
> **`Pulse` init logging** is tightened: duplicate initialization logs a **warning** that new config is ignored, and init failures log with **`exc_info=True`** for stack traces.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3abb6148adbda7e81c7661950771884736825d00. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->