### PR TITLE
Bump version to 0.4.11

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('requirements.txt') as f:
 
 setup(
     name='singlestore_pulse',
-    version='0.4.10',
+    version='0.4.11',
     packages=find_packages(),
     description='Singlestore Python SDK for OpenTelemetry Integration',
     long_description=open('README.md').read(),


### PR DESCRIPTION
## Summary

Version bump to cut the **v0.4.11** release, which packages the changes merged in #66:

- `traceloop-sdk` `0.40.7` → `0.52.6`, otel `1.33.1` → `1.38.0`
- pinned the OpenLLMetry instrumentors (`langchain`/`openai`/`anthropic`/`bedrock`/`ollama`) to `0.52.6` (`<0.53` keeps pre-GenAI-semconv span names)
- Pulse init hardening (warn on re-init, `exc_info` on failures)
- `setup.py` filters comments/blank lines when reading `requirements.txt`

`setup.py` `version` `0.4.10` → `0.4.11` so the installed package version matches the `v0.4.11` tag.

## Test Plan

- Built the full nova-style image (jupyter base → `pip install` pulse, then s2ai + genie + aiobotocore) from these branches: `pip check` clean; resolves to traceloop `0.52.6`, instrumentation-langchain `0.52.6`, instrumentation-httpx `0.59b0`, otel `1.38.0`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line version metadata change with no runtime or dependency edits in this diff.
> 
> **Overview**
> Bumps the **`singlestore_pulse`** package version in `setup.py` from **`0.4.10`** to **`0.4.11`** so the published wheel/sdist version matches the **`v0.4.11`** release tag.
> 
> This release cut is metadata-only in the diff; dependency and behavior updates described for v0.4.11 (e.g. traceloop/otel bumps, init hardening) are already on the branch from prior merges such as #66.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bb942815e9bf0852635668e97ec9157d3dc155f9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->