### PR TITLE
Add repository license and code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # Default owner for all files in this repository.
-* @aanshu-ss
+* aanshu@singlestore.com hniemchenko-ua@singlestore.com nagrawal@singlestore.com rgonzales@singlestore.com

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default owner for all files in this repository.
+* @aanshu-ss

--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,5 @@
 Copyright © 2026 SingleStore, Inc. All rights reserved.
 
-This software and associated documentation files in object and source code form (the “Software”) are the confidential and proprietary information of SingleStore, Inc. and may only be used under a valid licence granted by Singlestore Inc.
+This software and associated documentation files in object and source code form (the “Software”) are the confidential and proprietary information of SingleStore, Inc. and may only be used under a valid licence granted by Singlestore, Inc.
 
 Save as aforesaid, no part of the Software may be used, reproduced, modified, distributed, transmitted, de-complied, reverse-engineered, archived or disclosed in any form or by any means without the prior written permission of SingleStore, Inc.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,5 @@
+Copyright © 2026 SingleStore, Inc. All rights reserved.
+
+This software and associated documentation files in object and source code form (the “Software”) are the confidential and proprietary information of SingleStore, Inc. and may only be used under a valid licence granted by Singlestore Inc.
+
+Save as aforesaid, no part of the Software may be used, reproduced, modified, distributed, transmitted, de-complied, reverse-engineered, archived or disclosed in any form or by any means without the prior written permission of SingleStore, Inc.


### PR DESCRIPTION
## Summary
- Add the required SingleStore proprietary license text for ISO compliance.
- Add `.github/CODEOWNERS` to identify default repository owners.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and GitHub metadata only; no runtime, security, or data-path changes.
> 
> **Overview**
> Adds **repository governance and compliance** artifacts only—no application code changes.
> 
> Introduces a root **`LICENSE`** with SingleStore’s proprietary terms (2026 copyright, licence-required use, restrictions on reproduction and reverse engineering) for ISO compliance. Adds **`.github/CODEOWNERS`** with a default `*` rule assigning four SingleStore emails as owners for all paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c962b1af741e76c92559caf3f7e6a5ec92a7bfa8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->