### PR TITLE
Bump version to 0.4.12

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('requirements.txt') as f:
 
 setup(
     name='singlestore_pulse',
-    version='0.4.11',
+    version='0.4.12',
     packages=find_packages(),
     description='Singlestore Python SDK for OpenTelemetry Integration',
     long_description=open('README.md').read(),


### PR DESCRIPTION
## Summary

Version bump to cut the **v0.4.12** release, which packages the changes merged in #72:

- sqlbot now reports a stable `service.name` (`sqlbot`, trailing build timestamp stripped) instead of the ipykernel launcher path, so the notebook tier shows up as a real service-map node.
- emits the canonical OTel resource keys (`org.id`, `project.id`, `service.version`, `deployment.environment.name`) alongside the existing `singlestore.*` keys, so notebook spans join the Go services in trace and resource queries.
- `service_name()` falls back to `sqlbot` for unset, placeholder (`MY_APP_NAME`), and timestamp-only app names.

`setup.py` `version` `0.4.11` → `0.4.12` so the installed package version matches the `v0.4.12` tag.

## Test Plan

- Version bump is metadata-only in this diff; the behavior changes were reviewed and merged in #72 (`py_compile` clean, with post-deploy `pulse.otel_traces` verification documented there).
- `setup.py --version` reports `0.4.12`, and `setup.py` is the only file carrying the package version, so the bump matches the `v0.4.12` tag.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line version metadata change with no runtime or dependency logic changes in this PR.
> 
> **Overview**
> Bumps the **`singlestore_pulse`** package version in `setup.py` from **`0.4.11`** to **`0.4.12`** so the published wheel/sdist version matches the **v0.4.12** release tag.
> 
> This diff is **metadata-only**; the functional OTel/sqlbot changes referenced for this release were merged separately (e.g. #72) and are not modified here.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e590672e70eb9d7862e87f32fe46b6441e8000d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->