### PR TITLE
Set service.name on pulse log providers (fix unknown_service logs)

### DIFF
--- a/pulse_otel/main.py
+++ b/pulse_otel/main.py
@@ -116,6 +116,9 @@ class Pulse:
 		try:
 			
 			self.config = get_environ_vars()
+			# Reuse the attrs Traceloop puts on spans for the log providers below; without a
+			# Resource, OTel stamps every log record with service.name="unknown_service".
+			log_resource = Resource.create({**self.config, SERVICE_NAME: service_name()})
 			if write_to_traceloop and api_key:
 				log_exporter = self.init_log_provider()
 				set_global_content_tracing(False)
@@ -144,7 +147,7 @@ class Pulse:
 				# create json log exporter for live logs
 				jsonl_file_exporter = get_jsonl_file_exporter()
 				if jsonl_file_exporter is not None:
-					log_provider = LoggerProvider()
+					log_provider = LoggerProvider(resource=log_resource)
 					_logs.set_logger_provider(log_provider)
 					log_provider.add_log_record_processor(SimpleLogRecordProcessor(jsonl_file_exporter))
 					logging.root.addHandler(LoggingHandler()) # add filehandler to root logger
@@ -195,7 +198,7 @@ class Pulse:
 					Use the provided OTLP collector endpoint
 					First, a new LoggerProvider is created and set as the global logger provider. This object manages loggers and their configuration for the application. Next, an OTLPLogExporter is instantiated with the given endpoint, which is responsible for sending log records to the OTLP collector. The exporter is wrapped in a BatchLogRecordProcessor, which batches log records for efficient export, and this processor is registered with the logger provider.
 				"""
-				log_provider = LoggerProvider()
+				log_provider = LoggerProvider(resource=log_resource)
 				_logs.set_logger_provider(log_provider)
 
 				# create json log exporter for live logs
@@ -286,7 +289,7 @@ class Pulse:
 		Initializes the log provider and sets up the logging configuration.
 		"""
 		# Create the log provider and processor
-		log_provider = LoggerProvider()
+		log_provider = LoggerProvider(resource=Resource.create({**self.config, SERVICE_NAME: service_name()}))
 		log_exporter = FileLogExporter(LOCAL_LOGS_FILE)
 		log_provider.add_log_record_processor(BatchLogRecordProcessor(log_exporter))
 


### PR DESCRIPTION
## Summary

Every Aura Analyst log row in `pulse.otel_logs` shows `service.name = "unknown_service"`, so logs can't be filtered by service or joined to traces by service. The cause is that `pulse_otel` builds its `LoggerProvider`s without a Resource — OpenTelemetry then stamps its default `unknown_service`. Spans are unaffected because Traceloop already attaches a Resource.

This builds the same Resource the trace path uses — `service.name` plus the env-derived `org.id` / `project.id` / `service.version` — and passes it to every log provider:

- the OTLP->Pulse path (the one feeding `pulse.otel_logs`)
- the `only_live_logs` JSONL path
- `init_log_provider()` (the local file / Traceloop path)

Agent-container stdlib logs from s2ai and genie are bridged onto this provider by the `LoggingHandler` on the root logger, so they inherit the resource too — no change needed in those consumers.

## Test Plan

- `python -m py_compile pulse_otel/main.py` is clean.
- Confirmed the OTel mechanism directly: a bare `LoggerProvider()` resolves `service.name` to `unknown_service`, while `LoggerProvider(resource=Resource.create({**config, SERVICE_NAME: service_name()}))` resolves it to the app name and carries `project.id` / `org.id` / `service.version`.
- The full package import / test suite was not run in this environment (the local venv is missing runtime deps such as grpc/idna).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Telemetry metadata-only change on log export paths; no auth, data mutation, or control-flow changes beyond resource attachment on existing providers.
> 
> **Overview**
> **Fixes `service.name = "unknown_service"` on exported OpenTelemetry logs** by attaching a `Resource` when constructing `LoggerProvider`s, matching what Traceloop already does for traces.
> 
> `Pulse.__init__` now builds `log_resource` from `get_environ_vars()` plus `service_name()` and passes it into the **only-live-logs JSONL** path and the **default OTLP → Pulse** path that feeds `pulse.otel_logs`. **`init_log_provider()`** (local file / Traceloop logging) uses the same resource shape so file and bridged stdlib logs carry `service.name`, `org.id`, `project.id`, and `service.version`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f0785676a475a7913809ca004e0a1b0950bb34bb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->