### PR TITLE
Propagate per-process identity into W3C baggage on aura-otel keys + seed util

### DIFF
--- a/pulse_otel/__init__.py
+++ b/pulse_otel/__init__.py
@@ -1,2 +1,3 @@
-from pulse_otel.main import Pulse, CustomFileSpanExporter, FileLogExporter, pulse_agent, pulse_tool, observe, traced_function, setup_json_file_logger
+from pulse_otel.main import Pulse, CustomFileSpanExporter, FileLogExporter, pulse_agent, pulse_tool, observe, traced_function, setup_json_file_logger, seed_identity_baggage
 from pulse_otel.util import is_s2_owned_app
+from pulse_otel.consts import BAGGAGE_ORG, BAGGAGE_PROJECT, BAGGAGE_NOVA_ID, BAGGAGE_NOVA_TYPE, BAGGAGE_NOVA_NAME

--- a/pulse_otel/__init__.py
+++ b/pulse_otel/__init__.py
@@ -1,3 +1,4 @@
-from pulse_otel.main import Pulse, CustomFileSpanExporter, FileLogExporter, pulse_agent, pulse_tool, observe, traced_function, setup_json_file_logger, seed_identity_baggage
+from pulse_otel.main import Pulse, CustomFileSpanExporter, FileLogExporter, pulse_agent, pulse_tool, observe, traced_function, setup_json_file_logger
+from pulse_otel.identity import seed_identity_baggage
 from pulse_otel.util import is_s2_owned_app
 from pulse_otel.consts import BAGGAGE_ORG, BAGGAGE_PROJECT, BAGGAGE_NOVA_ID, BAGGAGE_NOVA_TYPE, BAGGAGE_NOVA_NAME

--- a/pulse_otel/consts.py
+++ b/pulse_otel/consts.py
@@ -28,6 +28,14 @@ PROJECT_ID = "project.id"
 SERVICE_VERSION = "service.version"
 DEPLOYMENT_ENV = "deployment.environment.name"
 
+# aura-otel cross-service W3C baggage keys — MUST match github.com/singlestore/aura-otel/otelctx
+# (BaggageOrg/Project/NovaID/NovaType/NovaName); the Go services resolve identity from these.
+BAGGAGE_ORG = "org"
+BAGGAGE_PROJECT = "project"
+BAGGAGE_NOVA_ID = "nova.id"
+BAGGAGE_NOVA_TYPE = "nova.type"
+BAGGAGE_NOVA_NAME = "nova.name"
+
 # Placeholder app name from DEFAULT_ENV_VARIABLES — must never leak into service.version.
 APP_NAME_PLACEHOLDER = "MY_APP_NAME"
 

--- a/pulse_otel/identity.py
+++ b/pulse_otel/identity.py
@@ -1,0 +1,62 @@
+"""Per-process identity baggage on the aura-otel contract keys."""
+
+import os
+
+from opentelemetry.baggage import set_baggage
+from opentelemetry.baggage.propagation import W3CBaggagePropagator
+from opentelemetry.context import get_current
+from opentelemetry.propagators.textmap import default_setter
+
+from pulse_otel.consts import (
+	APP_NAME_PLACEHOLDER,
+	BAGGAGE_ORG,
+	BAGGAGE_PROJECT,
+	BAGGAGE_NOVA_ID,
+	BAGGAGE_NOVA_TYPE,
+	BAGGAGE_NOVA_NAME,
+)
+
+
+def _process_identity_baggage():
+	"""Fixed per-process identity (org/project + the agent's nova app) on the
+	aura-otel contract keys, from the notebook-server env. Per-request dims
+	(session/domain) are not here; the caller seeds those. Empty/placeholder
+	values are dropped."""
+	name = os.getenv("SINGLESTOREDB_APP_NAME", "")
+	identity = {
+		BAGGAGE_ORG: os.getenv("SINGLESTOREDB_ORGANIZATION", ""),
+		BAGGAGE_PROJECT: os.getenv("SINGLESTOREDB_PROJECT", ""),
+		BAGGAGE_NOVA_ID: os.getenv("SINGLESTOREDB_APP_ID", ""),
+		BAGGAGE_NOVA_TYPE: os.getenv("SINGLESTOREDB_APP_TYPE", ""),
+		BAGGAGE_NOVA_NAME: "" if name == APP_NAME_PLACEHOLDER else name,
+	}
+	return {k: v for k, v in identity.items() if v}
+
+
+def _apply_identity_baggage(context, identity):
+	ctx = context if context is not None else get_current()
+	for key, value in identity.items():
+		ctx = set_baggage(key, value, context=ctx)
+	return ctx
+
+
+def seed_identity_baggage(context=None):
+	"""Seed this process's identity (org/project/nova, on the aura-otel contract
+	keys) onto *context* and return it. The global propagator installed by Pulse
+	already injects these on every outbound call; call this only to seed a context
+	explicitly. Per-request dims (session/domain) are the caller's job."""
+	return _apply_identity_baggage(context, _process_identity_baggage())
+
+
+class _IdentityBaggagePropagator(W3CBaggagePropagator):
+	"""W3C baggage propagator that also injects the per-process identity from
+	_process_identity_baggage() on inject, so downstream Go services stamp
+	org/project/nova from baggage. Non-identity inbound baggage passes through."""
+
+	def __init__(self):
+		super().__init__()
+		self._identity = _process_identity_baggage()
+
+	def inject(self, carrier, context=None, setter=default_setter):
+		ctx = _apply_identity_baggage(context, self._identity)
+		super().inject(carrier, context=ctx, setter=setter)

--- a/pulse_otel/main.py
+++ b/pulse_otel/main.py
@@ -94,6 +94,21 @@ def _process_identity_baggage():
 	return {k: v for k, v in identity.items() if v}
 
 
+def _apply_identity_baggage(context, identity):
+	ctx = context if context is not None else get_current()
+	for key, value in identity.items():
+		ctx = set_baggage(key, value, context=ctx)
+	return ctx
+
+
+def seed_identity_baggage(context=None):
+	"""Seed this process's identity (org/project/nova, on the aura-otel contract
+	keys) onto *context* and return it. The global propagator installed by Pulse
+	already injects these on every outbound call; call this only to seed a context
+	explicitly. Per-request dims (session/domain) are the caller's job."""
+	return _apply_identity_baggage(context, _process_identity_baggage())
+
+
 class _IdentityBaggagePropagator(W3CBaggagePropagator):
 	"""W3C baggage propagator that also injects the per-process identity from
 	_process_identity_baggage() on inject, so downstream Go services stamp
@@ -104,9 +119,7 @@ class _IdentityBaggagePropagator(W3CBaggagePropagator):
 		self._identity = _process_identity_baggage()
 
 	def inject(self, carrier, context=None, setter=default_setter):
-		ctx = context if context is not None else get_current()
-		for key, value in self._identity.items():
-			ctx = set_baggage(key, value, context=ctx)
+		ctx = _apply_identity_baggage(context, self._identity)
 		super().inject(carrier, context=ctx, setter=setter)
 
 

--- a/pulse_otel/main.py
+++ b/pulse_otel/main.py
@@ -29,6 +29,10 @@ from opentelemetry.sdk.trace.export import BatchSpanProcessor
 from opentelemetry.sdk.resources import SERVICE_NAME, Resource
 from opentelemetry.instrumentation.logging import LoggingInstrumentor
 from opentelemetry.instrumentation.requests import RequestsInstrumentor
+from opentelemetry.propagate import set_global_textmap
+from opentelemetry.propagators.composite import CompositePropagator
+from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapPropagator
+from opentelemetry.baggage.propagation import W3CBaggagePropagator
 
 from fastapi import Request
 
@@ -244,6 +248,10 @@ class Pulse:
 					This sets the minimum level for the root logger. Only log records at INFO level and above will be passed from the logger to the handler.
 				"""
 				logging.basicConfig(level=logging.INFO)
+				# Pin the W3C tracecontext + baggage propagators so downstream propagate.inject/extract stays deterministic regardless of any OTEL_PROPAGATORS env.
+				set_global_textmap(
+					CompositePropagator([TraceContextTextMapPropagator(), W3CBaggagePropagator()])
+				)
 				Traceloop.init(
 					app_name=service_name(),
 					disable_batch=True,

--- a/pulse_otel/main.py
+++ b/pulse_otel/main.py
@@ -13,7 +13,7 @@ from opentelemetry import _logs
 from opentelemetry import trace
 from opentelemetry.propagate import extract
 from opentelemetry.trace import SpanKind
-from opentelemetry.context import attach, set_value, get_current
+from opentelemetry.context import attach, set_value
 from opentelemetry.sdk._logs import LoggerProvider, LoggingHandler, LogData
 from opentelemetry.sdk._logs.export import BatchLogRecordProcessor, LogExporter, LogExportResult, SimpleLogRecordProcessor
 from opentelemetry.sdk.trace.export import SpanExporter, SpanExportResult
@@ -32,9 +32,6 @@ from opentelemetry.instrumentation.requests import RequestsInstrumentor
 from opentelemetry.propagate import set_global_textmap
 from opentelemetry.propagators.composite import CompositePropagator
 from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapPropagator
-from opentelemetry.baggage.propagation import W3CBaggagePropagator
-from opentelemetry.baggage import set_baggage
-from opentelemetry.propagators.textmap import default_setter
 
 from fastapi import Request
 
@@ -57,14 +54,9 @@ from pulse_otel.consts import (
 	LOCAL_TRACES_FILE,
 	LOCAL_LOGS_FILE,
 	PROJECT,
-	APP_NAME_PLACEHOLDER,
-	BAGGAGE_ORG,
-	BAGGAGE_PROJECT,
-	BAGGAGE_NOVA_ID,
-	BAGGAGE_NOVA_TYPE,
-	BAGGAGE_NOVA_NAME,
 	LIVE_LOGS_FILE_PATH,
 )
+from pulse_otel.identity import _IdentityBaggagePropagator
 import logging
 
 _pulse_instance = None
@@ -76,51 +68,6 @@ tracer = trace.get_tracer(__name__)
 
 # Run the OTel collector reachability check at import time for analyst kernels
 _perform_otel_collector_reachability_check()
-
-
-def _process_identity_baggage():
-	"""Fixed per-process identity (org/project + the agent's nova app) on the
-	aura-otel contract keys, from the notebook-server env. Per-request dims
-	(session/domain) are not here; the caller seeds those. Empty/placeholder
-	values are dropped."""
-	name = os.getenv("SINGLESTOREDB_APP_NAME", "")
-	identity = {
-		BAGGAGE_ORG: os.getenv("SINGLESTOREDB_ORGANIZATION", ""),
-		BAGGAGE_PROJECT: os.getenv("SINGLESTOREDB_PROJECT", ""),
-		BAGGAGE_NOVA_ID: os.getenv("SINGLESTOREDB_APP_ID", ""),
-		BAGGAGE_NOVA_TYPE: os.getenv("SINGLESTOREDB_APP_TYPE", ""),
-		BAGGAGE_NOVA_NAME: "" if name == APP_NAME_PLACEHOLDER else name,
-	}
-	return {k: v for k, v in identity.items() if v}
-
-
-def _apply_identity_baggage(context, identity):
-	ctx = context if context is not None else get_current()
-	for key, value in identity.items():
-		ctx = set_baggage(key, value, context=ctx)
-	return ctx
-
-
-def seed_identity_baggage(context=None):
-	"""Seed this process's identity (org/project/nova, on the aura-otel contract
-	keys) onto *context* and return it. The global propagator installed by Pulse
-	already injects these on every outbound call; call this only to seed a context
-	explicitly. Per-request dims (session/domain) are the caller's job."""
-	return _apply_identity_baggage(context, _process_identity_baggage())
-
-
-class _IdentityBaggagePropagator(W3CBaggagePropagator):
-	"""W3C baggage propagator that also injects the per-process identity from
-	_process_identity_baggage() on inject, so downstream Go services stamp
-	org/project/nova from baggage. Inbound/per-request baggage passes through."""
-
-	def __init__(self):
-		super().__init__()
-		self._identity = _process_identity_baggage()
-
-	def inject(self, carrier, context=None, setter=default_setter):
-		ctx = _apply_identity_baggage(context, self._identity)
-		super().inject(carrier, context=ctx, setter=setter)
 
 
 class Pulse:

--- a/pulse_otel/main.py
+++ b/pulse_otel/main.py
@@ -13,7 +13,7 @@ from opentelemetry import _logs
 from opentelemetry import trace
 from opentelemetry.propagate import extract
 from opentelemetry.trace import SpanKind
-from opentelemetry.context import attach, set_value
+from opentelemetry.context import attach, set_value, get_current
 from opentelemetry.sdk._logs import LoggerProvider, LoggingHandler, LogData
 from opentelemetry.sdk._logs.export import BatchLogRecordProcessor, LogExporter, LogExportResult, SimpleLogRecordProcessor
 from opentelemetry.sdk.trace.export import SpanExporter, SpanExportResult
@@ -33,6 +33,8 @@ from opentelemetry.propagate import set_global_textmap
 from opentelemetry.propagators.composite import CompositePropagator
 from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapPropagator
 from opentelemetry.baggage.propagation import W3CBaggagePropagator
+from opentelemetry.baggage import set_baggage
+from opentelemetry.propagators.textmap import default_setter
 
 from fastapi import Request
 
@@ -55,6 +57,12 @@ from pulse_otel.consts import (
 	LOCAL_TRACES_FILE,
 	LOCAL_LOGS_FILE,
 	PROJECT,
+	APP_NAME_PLACEHOLDER,
+	BAGGAGE_ORG,
+	BAGGAGE_PROJECT,
+	BAGGAGE_NOVA_ID,
+	BAGGAGE_NOVA_TYPE,
+	BAGGAGE_NOVA_NAME,
 	LIVE_LOGS_FILE_PATH,
 )
 import logging
@@ -68,6 +76,39 @@ tracer = trace.get_tracer(__name__)
 
 # Run the OTel collector reachability check at import time for analyst kernels
 _perform_otel_collector_reachability_check()
+
+
+def _process_identity_baggage():
+	"""Fixed per-process identity (org/project + the agent's nova app) on the
+	aura-otel contract keys, from the notebook-server env. Per-request dims
+	(session/domain) are not here; the caller seeds those. Empty/placeholder
+	values are dropped."""
+	name = os.getenv("SINGLESTOREDB_APP_NAME", "")
+	identity = {
+		BAGGAGE_ORG: os.getenv("SINGLESTOREDB_ORGANIZATION", ""),
+		BAGGAGE_PROJECT: os.getenv("SINGLESTOREDB_PROJECT", ""),
+		BAGGAGE_NOVA_ID: os.getenv("SINGLESTOREDB_APP_ID", ""),
+		BAGGAGE_NOVA_TYPE: os.getenv("SINGLESTOREDB_APP_TYPE", ""),
+		BAGGAGE_NOVA_NAME: "" if name == APP_NAME_PLACEHOLDER else name,
+	}
+	return {k: v for k, v in identity.items() if v}
+
+
+class _IdentityBaggagePropagator(W3CBaggagePropagator):
+	"""W3C baggage propagator that also injects the per-process identity from
+	_process_identity_baggage() on inject, so downstream Go services stamp
+	org/project/nova from baggage. Inbound/per-request baggage passes through."""
+
+	def __init__(self):
+		super().__init__()
+		self._identity = _process_identity_baggage()
+
+	def inject(self, carrier, context=None, setter=default_setter):
+		ctx = context if context is not None else get_current()
+		for key, value in self._identity.items():
+			ctx = set_baggage(key, value, context=ctx)
+		super().inject(carrier, context=ctx, setter=setter)
+
 
 class Pulse:
 	def __init__(
@@ -250,7 +291,7 @@ class Pulse:
 				logging.basicConfig(level=logging.INFO)
 				# Pin the W3C tracecontext + baggage propagators so downstream propagate.inject/extract stays deterministic regardless of any OTEL_PROPAGATORS env.
 				set_global_textmap(
-					CompositePropagator([TraceContextTextMapPropagator(), W3CBaggagePropagator()])
+					CompositePropagator([TraceContextTextMapPropagator(), _IdentityBaggagePropagator()])
 				)
 				Traceloop.init(
 					app_name=service_name(),

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('requirements.txt') as f:
 
 setup(
     name='singlestore_pulse',
-    version='0.4.12',
+    version='0.4.13',
     packages=find_packages(),
     description='Singlestore Python SDK for OpenTelemetry Integration',
     long_description=open('README.md').read(),

--- a/tests/test_identity.py
+++ b/tests/test_identity.py
@@ -1,0 +1,66 @@
+import os
+from unittest.mock import patch
+
+from opentelemetry.baggage import get_all
+from opentelemetry.context import Context
+
+from pulse_otel.consts import (
+    APP_NAME_PLACEHOLDER,
+    BAGGAGE_ORG,
+    BAGGAGE_PROJECT,
+    BAGGAGE_NOVA_ID,
+    BAGGAGE_NOVA_TYPE,
+    BAGGAGE_NOVA_NAME,
+)
+from pulse_otel.identity import _IdentityBaggagePropagator, seed_identity_baggage
+
+
+@patch.dict(
+    os.environ,
+    {
+        "SINGLESTOREDB_ORGANIZATION": "org1",
+        "SINGLESTOREDB_PROJECT": "proj1",
+        "SINGLESTOREDB_APP_ID": "app1",
+        "SINGLESTOREDB_APP_TYPE": "AGENT",
+        "SINGLESTOREDB_APP_NAME": "sqlbot",
+    },
+    clear=True,
+)
+def test_seed_identity_baggage_sets_all_keys():
+    bag = get_all(seed_identity_baggage(Context()))
+    assert bag[BAGGAGE_ORG] == "org1"
+    assert bag[BAGGAGE_PROJECT] == "proj1"
+    assert bag[BAGGAGE_NOVA_ID] == "app1"
+    assert bag[BAGGAGE_NOVA_TYPE] == "AGENT"
+    assert bag[BAGGAGE_NOVA_NAME] == "sqlbot"
+
+
+@patch.dict(os.environ, {"SINGLESTOREDB_ORGANIZATION": "org1"}, clear=True)
+def test_seed_identity_baggage_drops_empty_keys():
+    bag = get_all(seed_identity_baggage(Context()))
+    assert bag[BAGGAGE_ORG] == "org1"
+    assert BAGGAGE_PROJECT not in bag
+    assert BAGGAGE_NOVA_ID not in bag
+
+
+@patch.dict(
+    os.environ,
+    {"SINGLESTOREDB_ORGANIZATION": "org1", "SINGLESTOREDB_APP_NAME": APP_NAME_PLACEHOLDER},
+    clear=True,
+)
+def test_seed_identity_baggage_drops_placeholder_app_name():
+    bag = get_all(seed_identity_baggage(Context()))
+    assert BAGGAGE_NOVA_NAME not in bag
+
+
+@patch.dict(
+    os.environ,
+    {"SINGLESTOREDB_ORGANIZATION": "org1", "SINGLESTOREDB_APP_ID": "app1"},
+    clear=True,
+)
+def test_propagator_injects_identity_into_baggage_header():
+    carrier = {}
+    _IdentityBaggagePropagator().inject(carrier, context=Context())
+    assert "baggage" in carrier
+    assert "org1" in carrier["baggage"]
+    assert "app1" in carrier["baggage"]


### PR DESCRIPTION
## Summary

Makes pulse the source of cross-service identity on Aura traces. The global text-map propagator is pinned (W3C tracecontext + baggage) and extended so it injects this process's identity — `org` / `project` / `nova.id` / `nova.type` / `nova.name`, read from the `SINGLESTOREDB_*` env on the aura-otel contract keys — onto baggage on every outbound call. Downstream Go services (UMG, Aura Context) resolve those keys to stamp identity on their own spans. Inbound / per-request baggage passes through unchanged.

Also exports a public `seed_identity_baggage(context)` — for code paths that seed explicitly rather than relying on the global propagator — and the `BAGGAGE_*` contract constants, so consumers share one source of truth for the keys.

## Notes

- Per-request dims (`session` / `domain`) are the caller's responsibility — not seeded here.
- Nexus app identity is intentionally **not** included: it's delivered via the k8s-attributes collector processor (pod annotation -> resource/span attribute), not a process env var, so it can't be env-seeded here.

## Release

Bumps to `0.4.13` (in `setup.py`), so consumers can pin the tagged release.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes global OTel propagation on the main Pulse init path, which affects how identity flows on outbound traced calls; scope is limited to observability baggage, not auth or data paths.
> 
> **Overview**
> Notebook-tier Pulse now stamps **org / project / nova** identity onto **W3C baggage** using the same keys as **aura-otel** Go services, so downstream services can join traces without relying only on span resource attrs.
> 
> On the default OTLP + Traceloop init path, the global text-map propagator is **pinned** to W3C tracecontext plus a custom baggage propagator that merges process identity from `SINGLESTOREDB_*` env on every **inject** (empty values and the placeholder app name are omitted). Callers can also use **`seed_identity_baggage(context)`** and the exported **`BAGGAGE_*`** constants for explicit context seeding.
> 
> Adds **`pulse_otel/identity.py`**, unit tests, public exports in **`__init__.py`**, and bumps the package to **0.4.13**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 898d424b53178f794adc00fd9f7aa75baa65e44c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->